### PR TITLE
Fix setup script to create dated notebook

### DIFF
--- a/scripts/setup_gcp_notebook.sh
+++ b/scripts/setup_gcp_notebook.sh
@@ -36,5 +36,16 @@ if [ ! -f "config.yaml" ]; then
     cp config.yaml.example config.yaml 2>/dev/null || echo "Please create and configure config.yaml"
 fi
 
+# Create a dated copy of the main notebook for this month's analysis
+NOTEBOOK_TEMPLATE="notebooks/CUD_Analysis_Walkthrough.ipynb"
+DATED_NOTEBOOK="notebooks/$(date +%Y-%m)_CUD_Analysis_Platform.ipynb"
+
+if [ -f "$NOTEBOOK_TEMPLATE" ]; then
+    cp "$NOTEBOOK_TEMPLATE" "$DATED_NOTEBOOK"
+    echo "✅ Created a new notebook for this month's analysis: ${DATED_NOTEBOOK}"
+else
+    echo "⚠️  Warning: Notebook template not found at ${NOTEBOOK_TEMPLATE}"
+fi
+
 echo "✅ Setup complete! You can now run the notebook."
-echo "📓 Open notebooks/2025-08_CUD_Analysis_Platform.ipynb to start"
+echo "📓 Open ${DATED_NOTEBOOK} to start"


### PR DESCRIPTION
The `setup_gcp_notebook.sh` script previously included an `echo` statement that instructed the user to open a dated notebook file, but it did not actually create this file.

This commit fixes this issue by adding logic to the script to:
1. Dynamically determine the current year and month.
2. Create a dated copy of the `CUD_Analysis_Walkthrough.ipynb` notebook (e.g., `2025-08_CUD_Analysis_Platform.ipynb`).
3. Update the final output message to point to the newly created file.

This ensures the script's behavior matches its instructions and provides a better user experience.